### PR TITLE
chore(actions-runner): add flux-cli and kubectl

### DIFF
--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -24,6 +24,7 @@ RUN \
         unrar \
         unzip \
         wget \
+        yq \
         zip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -27,6 +27,9 @@ RUN \
         zip \
     && rm -rf /var/lib/apt/lists/*
 
+COPY --from=ghcr.io/fluxcd/flux-cli:v2.3.0 /usr/local/bin/flux /usr/local/bin/flux
+COPY --from=registry.k8s.io/kubectl:v1.30.1 /bin/kubectl /usr/local/bin/kubectl
+
 USER runner
 
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"

--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -24,12 +24,12 @@ RUN \
         unrar \
         unzip \
         wget \
-        yq \
         zip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/fluxcd/flux-cli:v2.3.0 /usr/local/bin/flux /usr/local/bin/flux
 COPY --from=registry.k8s.io/kubectl:v1.30.1 /bin/kubectl /usr/local/bin/kubectl
+COPY --from=docker.io/mikefarah/yq:4.44.1 /usr/bin/yq /usr/local/bin/yq
 
 USER runner
 

--- a/apps/actions-runner/ci/goss.yaml
+++ b/apps/actions-runner/ci/goss.yaml
@@ -3,3 +3,9 @@
 file:
   /usr/bin/git:
     exists: true
+  /usr/local/bin/flux:
+    exists: true
+  /usr/local/bin/kubectl:
+    exists: true
+  /usr/local/bin/yq:
+    exists: true


### PR DESCRIPTION
Right now my github actions download and install flux on every invocation. Build them into the image instead.